### PR TITLE
Bump dependencies and upgrade SDK Version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,17 +1,18 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.ksp)
 }
 
 android {
     namespace = "com.bintianqi.hookdpm"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.bintianqi.hookdpm"
         minSdk = 23
-        targetSdk = 34
+        targetSdk = 36
         versionName = "1.1"
         versionCode = 2
     }

--- a/app/src/main/java/com/bintianqi/hookdpm/MainActivity.kt
+++ b/app/src/main/java/com/bintianqi/hookdpm/MainActivity.kt
@@ -36,7 +36,6 @@ class MainActivity : ComponentActivity() {
             val darkTheme = isSystemInDarkTheme()
             val view = LocalView.current
             SideEffect {
-                window.statusBarColor = Color.Transparent.toArgb()
                 WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
             }
             if(VERSION.SDK_INT >= 31) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-agp = "8.5.0"
-kt = "1.9.24"
-ksp = "1.9.24-1.0.20"
+agp = "8.10.1"
+kotlin = "2.1.20"
+ksp = "2.1.20-1.0.31"
 
-androidx-activity-compose = "1.9.0"
-material3 = "1.2.1"
+androidx-activity-compose = "1.10.1"
+material3 = "1.3.2"
 xposed-api = "82"
 yukihook-api = "1.2.0"
 
@@ -20,5 +20,6 @@ yukihook-ksp-xposed = { module = "com.highcapable.yukihookapi:ksp-xposed", name 
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kt" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Apr 27 09:45:11 CST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Bump AGP to 8.10.1, Kotlin to 2.1.20 and other dependencies to their latest versions. 
- Upgrade compileSdk, targetSdk to 36.